### PR TITLE
Make usable as a Unity package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 
 ## Installation
 
-Just clone this repo somewhere inside your Unity project's `Assets` folder.
+### Option 1: Via Unity Package Manager
+
+Add an entry to your project's `Packages/manifest.json` dependencies list using the package name "com.garettbass.unityextensions.arraydrawer"; e.g.:
+```json
+{
+  "dependencies": {
+    "com.garettbass.unityextensions.arraydrawer": "https://github.com/garettbass/UnityExtensions.ArrayDrawer.git"
+  }
+}
+```
+
+Alternatively, clone the project somewhere on your machine and add it as a [local package](https://docs.unity3d.com/Manual/upm-localpath.html).
+
+### Option 2: Manually
+
+Just clone this repo somewhere inside your Unity project's `Assets` or `Packages` folders.
 
 ## `ArrayDrawer`
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "com.garettbass.unityextensions.arraydrawer",
+  "version": "1.0.0",
+  "displayName": "Array Drawer",
+  "description": "ArrayDrawer is a base class like PropertyDrawer, but for arrays and lists.",
+  "unity": "2018.1",
+  "keywords": [
+    "Editor",
+    "Array",
+    "List",
+    "Inspector",
+    "PropertyDrawer"
+  ],
+  "author": {
+    "name": "Garett Bass",
+    "email": "garettbass@me.com",
+    "url": "garettbass.com"
+  }
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7f1a18d9fd9464f11a41d23fb1359391
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hi friend, hope you're well.

I've been doing some research on what it takes to leverage Unity's package manager system, and I only recently learned that you can add project dependencies using git urls.  I wanted to try it out on a self-contained and production-ready extension, and ArrayDrawer (well, pretty much all of your extensions) fit the bill perfectly.  I enjoyed the learning experience, and I figure it could be more valuable if I contribute those learnings back, but feel free to take it or leave it: I won't be offended if you'd prefer to keep this project free of external influences :)

Cheers,
Will