### PR TITLE
Fixes for reordering change checks and custom property labels

### DIFF
--- a/Editor/ReorderableListDrawer.cs
+++ b/Editor/ReorderableListDrawer.cs
@@ -111,6 +111,7 @@ namespace UnityExtensions
                     attribute,
                     fieldInfo,
                     property);
+            reorderableList.UpdateLabel(label);
             reorderableList.onBackgroundColor = onBackgroundColor;
             reorderableList.onSelectCallback += OnSelectCallback;
             reorderableList.DoGUI(position);

--- a/Editor/ReorderableListOfValues.cs
+++ b/Editor/ReorderableListOfValues.cs
@@ -153,6 +153,7 @@ namespace UnityExtensions
             {
                 Debug.LogException(ex);
             }
+            GUI.changed = true;
         }
 
         //----------------------------------------------------------------------
@@ -784,7 +785,7 @@ namespace UnityExtensions
 
         private GUIContent m_Label = new GUIContent();
 
-        private void UpdateLabel(GUIContent label)
+        internal void UpdateLabel(GUIContent label)
         {
             m_Label.image = label.image;
 


### PR DESCRIPTION
Fixes:

* Reordering elements now marks the GUI as changed to trigger ChangeChecks.

* Label is updated when drawing the array to support rendering non-default labels passed in via 'EditorGUI.PropertyField'